### PR TITLE
Remove the tilde from usernames

### DIFF
--- a/lib/POE/Component/Server/Twirc.pm
+++ b/lib/POE/Component/Server/Twirc.pm
@@ -544,6 +544,7 @@ sub START {
     $self->ircd->add_auth(
         mask     => $self->irc_mask,
         password => $self->irc_password,
+        no_tilde => 1,
     );
     $self->post_ircd('add_listener', port     => $self->irc_server_port,
                                      bindaddr => $self->irc_server_bindaddr);


### PR DESCRIPTION
As ident lookup in most cases will fail and the username will be prefixed with ~, change to add_auth() call to remove tildes.

Purely an aesthetic change, but more pleasing to the eye.