### PR TITLE
Don't hardcode perl in twirc script

### DIFF
--- a/bin/twirc
+++ b/bin/twirc
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use warnings;
 use strict;
 use FindBin;


### PR DESCRIPTION
Without this change it is a pain to use with non-vendor Perls (Perlbrew etc)