### PR TITLE
Remove rate_limit_status, it no longer works and isn't useful

### DIFF
--- a/lib/App/Twirc/Manual.pod
+++ b/lib/App/Twirc/Manual.pod
@@ -246,12 +246,6 @@ Mark a friend's tweet as a favorite.  Optionally, specify the number of tweets
 to display for selection with C<count>. (C<count> defaults to 3. The default
 can be changed with the L</"favorites_count"> option.)
 
-=item rate_limit_status
-
-Displays information about the remaining number of API requests available in
-the current hour. The C<rate_limit_status> command does not count against the
-limit, itself.
-
 =item help
 
 Display a simple help message listing the available command names.

--- a/lib/App/Twirc/Plugin/BangCommands.pm
+++ b/lib/App/Twirc/Plugin/BangCommands.pm
@@ -30,7 +30,6 @@ App::Twirc::Plugin::BangCommands - Commands prefixed with !
   # in your IRC clientt
   This is a status message (no "post" prefix necessary)
   !follow net_twitter
-  !rate_limit_status
 
 =head1 DESCRIPTION
 

--- a/lib/POE/Component/Server/Twirc.pm
+++ b/lib/POE/Component/Server/Twirc.pm
@@ -1220,28 +1220,6 @@ sub _handle_favorite {
     return 0; # unhandled
 };
 
-=item rate_limit_status
-
-Displays the remaining number of API requests available in the current hour.
-
-=cut
-
-event cmd_rate_limit_status => sub {
-    my ($self, $channel) = @_[OBJECT, ARG0];
-
-    if ( my $r = $self->twitter('rate_limit_status') ) {
-        my $reset_time = sprintf "%02d:%02d:%02d", (localtime $r->{reset_time_in_seconds})[2,1,0];
-        my $seconds_remaning = $r->{reset_time_in_seconds} - time;
-        my $time_remaning = sprintf "%d:%02d", int($seconds_remaning / 60), $seconds_remaning % 60;
-        $self->bot_says($channel, sprintf "%s API calls remaining for the next %s (until %s), hourly limit is %s",
-            $$r{remaining_hits},
-            $time_remaning,
-            $reset_time,
-            $$r{hourly_limit},
-        );
-    }
-};
-
 =item retweet I<screen_name> [I<count>]
 
 Re-tweet another user's status.  Specify the user by I<screen_name> and select from a
@@ -1439,7 +1417,7 @@ event cmd_help => sub {
     $self->bot_says($channel, "Available commands:");
     $self->bot_says($channel, join ' ' => sort qw/
         post follow unfollow block unblock whois notify favorite
-        rate_limit_status retweet report_spam
+        retweet report_spam
     /);
     $self->bot_says($channel, '/msg nick for a direct message.')
 };


### PR DESCRIPTION
Even if it did, with the 1.1 API limiting there is no meaningful way to display
it all

rate_limit_status gives a error 400 but it should still work, the endpoint
exists, Net::Twitter may have an issue