### PR TITLE
Twitter enable/disable_notifications calls are deprecated

### DIFF
--- a/README
+++ b/README
@@ -212,6 +212,10 @@ COMMAND REFERENCE
         Turns device notifications on or off for the list of one or more
         Twitter friends. The list is space separated.
 
+    retweets on|off twitter_screen_name...
+        Turns retweet display on your timeline on or off for the list of one
+        or more Twitter friends. The list is space separated.
+
     favorite friend [ count ]
         Mark a friend's tweet as a favorite. Optionally, specify the number
         of tweets to display for selection with "count". ("count" defaults

--- a/lib/App/Twirc/Manual.pod
+++ b/lib/App/Twirc/Manual.pod
@@ -255,6 +255,11 @@ name or email address.
 Turns device notifications on or off for the list of one or more Twitter
 friends.  The list is space separated.
 
+=item retweets on|off twitter_screen_name...
+
+Turns retweet display on your timeline on or off for the list of one or more
+Twitter friends.  The list is space separated.
+
 =item favorite friend [ count ]
 
 Mark a friend's tweet as a favorite.  Optionally, specify the number of tweets

--- a/lib/POE/Component/Server/Twirc.pm
+++ b/lib/POE/Component/Server/Twirc.pm
@@ -1181,7 +1181,7 @@ sub _update_fship {
     my @nicks = split /\s+/, $argstr;
     my $onoff = shift @nicks;
 
-    unless ( $onoff && $onoff =~ /^on|off$/ ) {
+    unless ( $onoff && $onoff =~ /^on$|^off$/ ) {
         $self->bot_says($channel, "Usage: $command on|off nick[ nick [...]]");
         return;
     }

--- a/lib/POE/Component/Server/Twirc.pm
+++ b/lib/POE/Component/Server/Twirc.pm
@@ -1150,9 +1150,9 @@ event cmd_whois => sub {
     }
 };
 
-=item notify I<on|off> I<id ...>
+=item notify I<on|off> I<screen_name ...>
 
-Turns device notifications on or off for the list of Twitter IDs.
+Turns mobile device notifications on or off for the list of I<screen_name>s.
 
 =cut
 
@@ -1167,9 +1167,10 @@ event cmd_notify => sub {
         return;
     }
 
-    my $method = $onoff eq 'on' ? 'enable_notifications' : 'disable_notifications';
+    my $setting = $onoff eq 'on' ? 1 : 0;
     for my $nick ( @nicks ) {
-        $self->twitter($method => { id => $nick });
+        $self->twitter(update_friendship => { screen_name => $nick,
+                                              device      => $setting});
     }
 };
 

--- a/t/99-pod_spelling.t
+++ b/t/99-pod_spelling.t
@@ -54,3 +54,4 @@ unfollow
 username
 verifier
 whois
+retweets


### PR DESCRIPTION
Switches notify to use 1.1 calls, adds the ability to set retweet preferences, doesn't update unless necessary and fixes an old bug