### PR TITLE
Make sure MooseX::Storage always has its JSON module (RT#86509)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,8 @@ requires 'Config::Any';
 requires 'Encode';
 requires 'FindBin';
 requires 'HTML::Entities';
+requires 'JSON::Any';
+requires 'JSON::MaybeXS';
 requires 'Log::Log4perl';
 requires 'LWP::UserAgent::POE'         => '0.02';
 requires 'Moose';


### PR DESCRIPTION
This will always install one extra dependency, but it is the only way to guarantee all CPAN Testers will pass, without adding a requirement on the latest [MooseX::Storage](https://metacpan.org/changes/distribution/MooseX-Storage)